### PR TITLE
Add CLI Parsing and Core Program Logic

### DIFF
--- a/include/cli.h
+++ b/include/cli.h
@@ -6,6 +6,7 @@ int parse_cli(int argc,
 			  char *argv[],
 			  char **target,
 			  char **ports,
+			  int *show_open,
 			  int *no_host_disc,
 			  int *force_ping,
 			  int *force_arp);

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,7 +1,27 @@
 #ifndef CLI_H
 #define CLI_H
 
+/**
+ * @brief Print usage information.
+ *
+ * @param stream Output stream (e.g., stdout or stderr).
+ */
 void usage(FILE *stream);
+
+/**
+ * @brief Parse command line arguments.
+ *
+ * @param argc Argument count.
+ * @param argv Argument vector.
+ * @param target Pointer to store the target IP address or domain.
+ * @param ports Pointer to store the ports to scan.
+ * @param show_open Flag to only show open ports.
+ * @param no_host_disc Flag to skip host discovery.
+ * @param force_ping Flag to force ICMP.
+ * @param force_arp Flag to force ARP.
+ * @param write_file Pointer to store the write_file path.
+ * @return int 0 on success, CLI_PARSE on error.
+ */
 int parse_cli(int argc,
 			  char *argv[],
 			  char **target,

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,0 +1,6 @@
+#ifndef CLI_H
+#define CLI_H
+
+void parse_cli(int argc, char *argv[]);
+
+#endif

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,6 +1,12 @@
 #ifndef CLI_H
 #define CLI_H
 
-void parse_cli(int argc, char *argv[]);
+void parse_cli(int argc,
+			   char *argv[],
+			   char **target,
+			   char **ports,
+			   int *no_host_disc,
+			   int *force_ping,
+			   int *force_arp);
 
 #endif

--- a/include/cli.h
+++ b/include/cli.h
@@ -9,6 +9,7 @@ int parse_cli(int argc,
 			  int *show_open,
 			  int *no_host_disc,
 			  int *force_ping,
-			  int *force_arp);
+			  int *force_arp,
+			  char **write_file);
 
 #endif

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,12 +1,13 @@
 #ifndef CLI_H
 #define CLI_H
 
-void parse_cli(int argc,
-			   char *argv[],
-			   char **target,
-			   char **ports,
-			   int *no_host_disc,
-			   int *force_ping,
-			   int *force_arp);
+void usage(FILE *stream);
+int parse_cli(int argc,
+			  char *argv[],
+			  char **target,
+			  char **ports,
+			  int *no_host_disc,
+			  int *force_ping,
+			  int *force_arp);
 
 #endif

--- a/include/error.h
+++ b/include/error.h
@@ -31,20 +31,21 @@ typedef enum err
 extern const char *const error_strings[];
 
 /**
- * @brief Prints a descriptive error message to `stderr` based on an error code.
+ * @brief Prints a descriptive error message to `stream` based on an error code.
  * Example usage:
  *
  * Example usage:
  * @code
  * int rv = ping("example.com");
  * if (rv != SUCCESS) {
- *     print_err("ping", rv);
+ *     print_err(stderr, "ping", rv);
  * }
  * @endcode
  *
+ * @param stream The output stream.
  * @param function The function.
  * @param err_val The returned value from the function.
  */
-void print_err(char *function, int err_val);
+void print_err(FILE *stream, char *function, int err_val);
 
 #endif

--- a/include/error.h
+++ b/include/error.h
@@ -24,6 +24,7 @@ typedef enum err
 	PTHREAD_CREATE,
 	SRC_ADDR,
 	UNKNOWN_FAMILY,
+	CLI_PARSE,
 	COUNT, /* Not used, only for assert */
 } err_t;
 

--- a/include/syn_scan.h
+++ b/include/syn_scan.h
@@ -13,14 +13,14 @@
  * @param address The target address to scan.
  * @param port_arr The array of ports to scan.
  * @param count The number of ports in the array.
- * @param print_state Whether to print the open ports.
+ * @param is_open_port Whether any open ports were found.
  * @param result_arr Pointer to an array to store the results of the scan.
  * @return `int` Returns SUCCESS on success, or an error code from `error.h` on failure.
  */
 int port_scan(char *address,
 			  unsigned short *port_arr,
 			  int count,
-			  int print_state,
+			  short *is_open_port,
 			  short **result_arr);
 
 /**

--- a/include/syn_scan.h
+++ b/include/syn_scan.h
@@ -1,6 +1,10 @@
 #ifndef SYN_SCAN_H
 #define SYN_SCAN_H
 
+#define UNKNOWN 0
+#define OPEN 1
+#define CLOSED 2
+
 /**
  * @brief Performs a SYN scan on the specified ports of a target address or
  * domain. If `print_state` is true, the open ports will be printed. An array
@@ -21,7 +25,7 @@ int port_scan(char *address,
 			  unsigned short *port_arr,
 			  int count,
 			  short *is_open_port,
-			  short **result_arr);
+			  unsigned short **result_arr);
 
 /**
  * @brief Parses a string with a format similar to `"1,2,3-5,6"`, and returns it

--- a/include/syn_scan.h
+++ b/include/syn_scan.h
@@ -1,7 +1,7 @@
 #ifndef SYN_SCAN_H
 #define SYN_SCAN_H
 
-#define UNKNOWN 0
+#define FILTERED 0
 #define OPEN 1
 #define CLOSED 2
 

--- a/include/syn_scan.h
+++ b/include/syn_scan.h
@@ -38,4 +38,11 @@ int port_scan(char *address,
  */
 unsigned short *parse_ports(const char *port_str, int *port_count);
 
+/**
+ * @brief Controls whether syn_scan should print results during testing.
+ *
+ * @param enable 1 to enable output, 0 to suppress output
+ */
+void set_test_print_flag(int enable);
+
 #endif

--- a/src/cli.c
+++ b/src/cli.c
@@ -25,14 +25,14 @@ void usage(FILE *stream)
 		banner(stream);
 	}
 	fprintf(stream,
-			"usage: disco target [-h] [-p port(s)] [-n] [-P] [-a]\n\n"
+			"usage: disco target [-h] [-p port(s)] [-n] [-P] [-a]\n"
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
 			"  -n, --no-check  : skip host discovery\n"
 			"  -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
 			"  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
-			"  -h, --help      : display this message\n\n");
+			"  -h, --help      : display this message\n");
 }
 
 int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_disc, int *force_ping, int *force_arp)
@@ -120,7 +120,14 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 		case '?':
 			if (optopt != 0)
 			{
-				fprintf(stderr, "ERROR: unknown option '-%c'\n\n", optopt);
+				if (optopt == 'p')
+				{
+					fprintf(stderr, "ERROR: missing port(s) for '-p'\n\n");
+				}
+				else
+				{
+					fprintf(stderr, "ERROR: unknown option '-%c'\n\n", optopt);
+				}
 			}
 			usage(stderr);
 			return -1;

--- a/src/cli.c
+++ b/src/cli.c
@@ -25,7 +25,7 @@ void usage(FILE *stream)
 		banner(stream);
 	}
 	fprintf(stream,
-			"usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a] [-w]\n"
+			"usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a] [-w file]\n"
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"

--- a/src/cli.c
+++ b/src/cli.c
@@ -25,7 +25,7 @@ void usage(FILE *stream)
 		banner(stream);
 	}
 	fprintf(stream,
-			"usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a]\n"
+			"usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a] [-w]\n"
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
@@ -33,11 +33,12 @@ void usage(FILE *stream)
 			"  -n, --no-check  : skip host status check\n"
 			"  -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
 			"  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
+			"  -w, --write     : write results to a file\n"
 			"  -h, --help      : display this message\n");
 }
 
 int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_open,
-			  int *no_host_disc, int *force_ping, int *force_arp)
+			  int *no_host_disc, int *force_ping, int *force_arp, char **write_file)
 {
 	/* Reset optind for multiple tests to work properly*/
 	optind = 1;
@@ -81,10 +82,16 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 				NULL,
 				'o',
 			},
+			{
+				"write",
+				required_argument,
+				NULL,
+				'w',
+			},
 			{0, 0, 0, 0}};
 
 	int option;
-	while ((option = getopt_long(argc, argv, "p:nhPao", options, NULL)) != -1)
+	while ((option = getopt_long(argc, argv, "p:nhPaow:", options, NULL)) != -1)
 	{
 		switch (option)
 		{
@@ -113,6 +120,20 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 				}
 			}
 			break;
+		case 'w':
+			if (optarg != NULL && write_file != NULL)
+			{
+				size_t len = strlen(optarg);
+				if (len > 0)
+				{
+					*write_file = malloc(len + 1);
+					if (*write_file)
+					{
+						strcpy(*write_file, optarg);
+					}
+				}
+			}
+			break;
 		case 'o':
 			*show_open = 1;
 			break;
@@ -134,6 +155,10 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 				if (optopt == 'p')
 				{
 					fprintf(stderr, "[-] Missing port(s) for '-p'\n\n");
+				}
+				else if (optopt == 'w')
+				{
+					fprintf(stderr, "[-] Missing file name for '-w'\n\n");
 				}
 				else
 				{

--- a/src/cli.c
+++ b/src/cli.c
@@ -88,12 +88,14 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 				if (len > 0)
 				{
 					int count = 0;
-					if (parse_ports(optarg, &count) == NULL)
+					unsigned short *temp_ports = parse_ports(optarg, &count);
+					if (temp_ports == NULL)
 					{
 						fprintf(stderr, "ERROR: invalid port specification: '-p %s'\n\n", optarg);
 						usage(stderr);
-						return -1 - 1;
+						return -1;
 					}
+					free(temp_ports);
 					/* Add one for null terminator */
 					*ports = malloc(len + 1);
 					if (*ports)
@@ -123,7 +125,7 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 			usage(stderr);
 			return -1;
 		default:
-			fprintf(stderr, "ERROR: unexpected getopt return -1 value: %c\n\n", option);
+			fprintf(stderr, "ERROR: unexpected argument: %c\n\n", option);
 			usage(stderr);
 			return -1;
 		}

--- a/src/cli.c
+++ b/src/cli.c
@@ -35,7 +35,7 @@ void usage(FILE *stream)
 			"  -h, --help      : display this message\n\n");
 }
 
-void parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_disc, int *force_ping, int *force_arp)
+int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_disc, int *force_ping, int *force_arp)
 {
 	/* Reset optind for multiple tests to work properly*/
 	optind = 1;
@@ -90,9 +90,9 @@ void parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host
 					int count = 0;
 					if (parse_ports(optarg, &count) == NULL)
 					{
-						fprintf(stderr, "Error: Invalid port specification: '-p %s'\n", optarg);
+						fprintf(stderr, "ERROR: invalid port specification: '-p %s'\n\n", optarg);
 						usage(stderr);
-						return;
+						return -1 - 1;
 					}
 					/* Add one for null terminator */
 					*ports = malloc(len + 1);
@@ -114,18 +114,18 @@ void parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host
 			break;
 		case 'h':
 			usage(stdout);
-			return;
+			return -1;
 		case '?':
 			if (optopt != 0)
 			{
-				fprintf(stderr, "Error: Unknown option '-%c'\n", optopt);
+				fprintf(stderr, "ERROR: unknown option '-%c'\n\n", optopt);
 			}
 			usage(stderr);
-			return;
+			return -1;
 		default:
-			fprintf(stderr, "Error: Unexpected getopt return value: %c\n", option);
+			fprintf(stderr, "ERROR: unexpected getopt return -1 value: %c\n\n", option);
 			usage(stderr);
-			return;
+			return -1;
 		}
 	}
 
@@ -154,10 +154,19 @@ void parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host
 		}
 	}
 
-	// TODO print error if -P and -a are used at the same time
-	/*
-	printf("No host discovery: %s\n", no_host_disc ? "yes" : "no");
-	printf("Use ping only: %s\n", use_ping ? "yes" : "no");
-	printf("Use ARP only: %s\n", use_arp ? "yes" : "no");
-	*/
+	if (*force_arp + *force_ping + *no_host_disc > 1)
+	{
+		fprintf(stderr, "ERROR: conflicting options. Only one of -P, -a and -n can be used at once\n\n");
+		usage(stderr);
+		return -1;
+	}
+
+	if (*target == NULL)
+	{
+		fprintf(stderr, "ERROR: no valid target specified\n\n");
+		usage(stderr);
+		return -1;
+	}
+
+	return 0;
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,11 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
+#include <arpa/inet.h>
+#include "../include/utils.h"
 
 void parse_cli(int argc, char *argv[])
 {
 
 	char *ports = NULL;
+	char *target = NULL;
 
 	static struct option options[] =
 		{
@@ -27,5 +30,23 @@ void parse_cli(int argc, char *argv[])
 		break;
 	}
 
-	printf("Ports: %s\n", ports);
+	/* Check unused options for valid domain or IP. First valid found is used */
+	if (!target)
+	{
+		while (optind < argc)
+		{
+			char *unused = argv[optind];
+			struct addrinfo *r = get_dst_addr_struct(unused, SOCK_RAW);
+			if (r != NULL)
+			{
+				target = unused;
+				free_dst_addr_struct(r);
+				break;
+			}
+			optind++;
+		}
+	}
+
+	printf("Ports: %s\n", ports ? ports : "none");
+	printf("Target: %s\n", target ? target : "none");
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -25,7 +25,7 @@ void usage(FILE *stream)
 		banner(stream);
 	}
 	fprintf(stream,
-			"usage: disco target [-h] [-p port(s)] [-n] [-P] [-a]\n"
+			"usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a]\n"
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"

--- a/src/cli.c
+++ b/src/cli.c
@@ -3,10 +3,17 @@
 #include <string.h>
 #include <getopt.h>
 #include <arpa/inet.h>
+
+#include "../include/error.h"
 #include "../include/syn_scan.h"
 #include "../include/utils.h"
 
-void banner(FILE *stream)
+/**
+ * @brief Prints the banner and usage information if -h or no arguments are given.
+ *
+ * @param stream Output stream (e.g., stdout or stderr).
+ */
+static void banner(FILE *stream)
 {
 	fprintf(stream,
 			"@@@@@@@,   **  ,@@@@@@@  ,@@@@@@@  ,@@@@@@@,\n"
@@ -122,7 +129,7 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 					{
 						fprintf(stderr, "[-] Invalid port specification: '-p %s'\n", optarg);
 						usage(stderr);
-						return -1;
+						return CLI_PARSE;
 					}
 					free(temp_ports);
 					/* Add one for null terminator */
@@ -162,7 +169,7 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 			break;
 		case 'h':
 			usage(stdout);
-			return -1;
+			return CLI_PARSE;
 		case '?':
 			if (optopt != 0)
 			{
@@ -180,11 +187,11 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 				}
 			}
 			usage(stderr);
-			return -1;
+			return CLI_PARSE;
 		default:
 			fprintf(stderr, "[-] Unexpected argument: %c\n", option);
 			usage(stderr);
-			return -1;
+			return CLI_PARSE;
 		}
 	}
 
@@ -217,14 +224,14 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 	{
 		fprintf(stderr, "[-] Conflicting options. Only one of -P, -a and -n can be used at once\n");
 		usage(stderr);
-		return -1;
+		return CLI_PARSE;
 	}
 
 	if (*target == NULL)
 	{
 		fprintf(stderr, "[-] No valid target specified\n");
 		usage(stderr);
-		return -1;
+		return CLI_PARSE;
 	}
 
 	return 0;

--- a/src/cli.c
+++ b/src/cli.c
@@ -4,11 +4,40 @@
 #include <arpa/inet.h>
 #include "../include/utils.h"
 
+void banner(void)
+{
+	printf("@@@@@@@,   **  ,@@@@@@@  ,@@@@@@@  ,@@@@@@@,\n"
+		   "**     **  **  @@        **        **     **\n"
+		   "**     **  **  '@@@@@@,  **        **     **\n"
+		   "**     **  **        **  **        **     **\n"
+		   "@@@@@@@'   **  @@@@@@@'  '@@@@@@@  '@@@@@@@'\n\n");
+}
+
+void usage(void)
+{
+	banner();
+	printf("disco - network utility for host discovery and port enumeration\n"
+		   "author: pilsnerfrajz\n\n"
+		   "usage: disco target [-h] [-p port(s)] [-n] [-P] [-a]\n\n"
+		   "options:\n"
+		   "  target          : host to scan (IP address or domain)\n"
+		   "  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
+		   "  -n, --no-check  : skip host discovery\n"
+		   "  -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
+		   "  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
+		   "  -h, --help      : display this message\n\n");
+}
+
 void parse_cli(int argc, char *argv[])
 {
+	/* Reset optind for multiple tests to work properly*/
+	optind = 1;
 
 	char *ports = NULL;
 	char *target = NULL;
+	int no_host_disc = 0;
+	int use_ping = 0;
+	int use_arp = 0;
 
 	static struct option options[] =
 		{
@@ -18,16 +47,57 @@ void parse_cli(int argc, char *argv[])
 				NULL,
 				'p',
 			},
+			{
+				"help",
+				no_argument,
+				NULL,
+				'h',
+			},
+			{
+				"no-check",
+				no_argument,
+				NULL,
+				'n',
+			},
+			{
+				"ping-only",
+				no_argument,
+				NULL,
+				'P',
+			},
+			{
+				"arp-only",
+				no_argument,
+				NULL,
+				'a',
+			},
 			{0, 0, 0, 0}};
 
-	switch (getopt_long(argc, argv, "p:", options, NULL))
+	int option;
+	while ((option = getopt_long(argc, argv, "p:nhPa", options, NULL)) != -1)
 	{
-	case 'p':
-		ports = optarg;
-		break;
-	default:
-		// usage
-		break;
+		switch (option)
+		{
+		case 'p':
+			ports = optarg;
+			break;
+		case 'n':
+			no_host_disc = 1;
+			break;
+		case 'P':
+			use_ping = 1;
+			break;
+		case 'a':
+			use_arp = 1;
+			break;
+		case 'h':
+			usage();
+			return;
+		default:
+			// TODO invalid option print
+			usage();
+			return;
+		}
 	}
 
 	/* Check unused options for valid domain or IP. First valid found is used */
@@ -47,6 +117,11 @@ void parse_cli(int argc, char *argv[])
 		}
 	}
 
+	// TODO print error if -P and -a are used at the same time
+
 	printf("Ports: %s\n", ports ? ports : "none");
 	printf("Target: %s\n", target ? target : "none");
+	printf("No host discovery: %s\n", no_host_disc ? "yes" : "no");
+	printf("Use ping only: %s\n", use_ping ? "yes" : "no");
+	printf("Use ARP only: %s\n", use_arp ? "yes" : "no");
 }

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+void parse_cli(int argc, char *argv[])
+{
+
+	char *ports = NULL;
+
+	static struct option options[] =
+		{
+			{
+				"ports",
+				required_argument,
+				NULL,
+				'p',
+			},
+			{0, 0, 0, 0}};
+
+	switch (getopt_long(argc, argv, "p:", options, NULL))
+	{
+	case 'p':
+		ports = optarg;
+		break;
+	default:
+		// usage
+		break;
+	}
+
+	printf("Ports: %s\n", ports);
+}

--- a/src/cli.c
+++ b/src/cli.c
@@ -91,7 +91,7 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 					unsigned short *temp_ports = parse_ports(optarg, &count);
 					if (temp_ports == NULL)
 					{
-						fprintf(stderr, "ERROR: invalid port specification: '-p %s'\n\n", optarg);
+						fprintf(stderr, "[-] Invalid port specification: '-p %s'\n\n", optarg);
 						usage(stderr);
 						return -1;
 					}
@@ -122,17 +122,17 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 			{
 				if (optopt == 'p')
 				{
-					fprintf(stderr, "ERROR: missing port(s) for '-p'\n\n");
+					fprintf(stderr, "[-] Missing port(s) for '-p'\n\n");
 				}
 				else
 				{
-					fprintf(stderr, "ERROR: unknown option '-%c'\n\n", optopt);
+					fprintf(stderr, "[-] Unknown option '-%c'\n\n", optopt);
 				}
 			}
 			usage(stderr);
 			return -1;
 		default:
-			fprintf(stderr, "ERROR: unexpected argument: %c\n\n", option);
+			fprintf(stderr, "[-] Unexpected argument: %c\n\n", option);
 			usage(stderr);
 			return -1;
 		}
@@ -165,14 +165,14 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 
 	if (*force_arp + *force_ping + *no_host_disc > 1)
 	{
-		fprintf(stderr, "ERROR: conflicting options. Only one of -P, -a and -n can be used at once\n\n");
+		fprintf(stderr, "[-] Conflicting options. Only one of -P, -a and -n can be used at once\n\n");
 		usage(stderr);
 		return -1;
 	}
 
 	if (*target == NULL)
 	{
-		fprintf(stderr, "ERROR: no valid target specified\n\n");
+		fprintf(stderr, "[-] No valid target specified\n\n");
 		usage(stderr);
 		return -1;
 	}

--- a/src/cli.c
+++ b/src/cli.c
@@ -29,13 +29,15 @@ void usage(FILE *stream)
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
+			"  -o, --open      : show open ports only\n"
 			"  -n, --no-check  : skip host status check\n"
 			"  -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
 			"  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
 			"  -h, --help      : display this message\n");
 }
 
-int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_disc, int *force_ping, int *force_arp)
+int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_open,
+			  int *no_host_disc, int *force_ping, int *force_arp)
 {
 	/* Reset optind for multiple tests to work properly*/
 	optind = 1;
@@ -73,6 +75,12 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 				NULL,
 				'a',
 			},
+			{
+				"open",
+				no_argument,
+				NULL,
+				'o',
+			},
 			{0, 0, 0, 0}};
 
 	int option;
@@ -104,6 +112,9 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *no_host_
 					}
 				}
 			}
+			break;
+		case 'o':
+			*show_open = 1;
 			break;
 		case 'n':
 			*no_host_disc = 1;

--- a/src/cli.c
+++ b/src/cli.c
@@ -29,7 +29,7 @@ void usage(FILE *stream)
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
-			"  -n, --no-check  : skip host discovery\n"
+			"  -n, --no-check  : skip host status check\n"
 			"  -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
 			"  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
 			"  -h, --help      : display this message\n");

--- a/src/cli.c
+++ b/src/cli.c
@@ -29,7 +29,7 @@ void usage(FILE *stream)
 			"options:\n"
 			"  target          : host to scan (IP address or domain)\n"
 			"  -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
-			"  -o, --open      : show open ports only\n"
+			"  -o, --open      : show open ports only (default: open or unknown)\n"
 			"  -n, --no-check  : skip host status check\n"
 			"  -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
 			"  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
@@ -84,7 +84,7 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 			{0, 0, 0, 0}};
 
 	int option;
-	while ((option = getopt_long(argc, argv, "p:nhPa", options, NULL)) != -1)
+	while ((option = getopt_long(argc, argv, "p:nhPao", options, NULL)) != -1)
 	{
 		switch (option)
 		{

--- a/src/cli.c
+++ b/src/cli.c
@@ -16,14 +16,6 @@ void banner(FILE *stream)
 			"@@@@@@@'   **  @@@@@@@'  '@@@@@@@  '@@@@@@@'\n\n"
 			"disco - network utility for host discovery and port enumeration\n"
 			"author: pilsnerfrajz\n\n");
-}
-
-void usage(FILE *stream)
-{
-	if (stream == stdout)
-	{
-		banner(stream);
-	}
 	fprintf(stream,
 			"usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a] [-w file]\n"
 			"options:\n"
@@ -35,6 +27,28 @@ void usage(FILE *stream)
 			"  -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
 			"  -w, --write     : write results to a file\n"
 			"  -h, --help      : display this message\n");
+}
+
+void usage(FILE *stream)
+{
+	if (stream == stdout)
+	{
+		banner(stream);
+	}
+	else
+	{
+		fprintf(stream,
+				"[!] usage: disco target [-h] [-p port(s)] [-o] [-n] [-P] [-a] [-w file]\n"
+				"    options:\n"
+				"      target          : host to scan (IP address or domain)\n"
+				"      -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80\n"
+				"      -o, --open      : show open ports only (default: open or unknown)\n"
+				"      -n, --no-check  : skip host status check\n"
+				"      -P, --ping-only : force ICMP host discovery (skip ARP attempt)\n"
+				"      -a, --arp-only  : force ARP host discovery (skip ICMP fallback)\n"
+				"      -w, --write     : write results to a file\n"
+				"      -h, --help      : display this message\n");
+	}
 }
 
 int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_open,
@@ -106,7 +120,7 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 					unsigned short *temp_ports = parse_ports(optarg, &count);
 					if (temp_ports == NULL)
 					{
-						fprintf(stderr, "[-] Invalid port specification: '-p %s'\n\n", optarg);
+						fprintf(stderr, "[-] Invalid port specification: '-p %s'\n", optarg);
 						usage(stderr);
 						return -1;
 					}
@@ -154,21 +168,21 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 			{
 				if (optopt == 'p')
 				{
-					fprintf(stderr, "[-] Missing port(s) for '-p'\n\n");
+					fprintf(stderr, "[-] Missing port(s) for '-p'\n");
 				}
 				else if (optopt == 'w')
 				{
-					fprintf(stderr, "[-] Missing file name for '-w'\n\n");
+					fprintf(stderr, "[-] Missing file name for '-w'\n");
 				}
 				else
 				{
-					fprintf(stderr, "[-] Unknown option '-%c'\n\n", optopt);
+					fprintf(stderr, "[-] Unknown option '-%c'\n", optopt);
 				}
 			}
 			usage(stderr);
 			return -1;
 		default:
-			fprintf(stderr, "[-] Unexpected argument: %c\n\n", option);
+			fprintf(stderr, "[-] Unexpected argument: %c\n", option);
 			usage(stderr);
 			return -1;
 		}
@@ -201,14 +215,14 @@ int parse_cli(int argc, char *argv[], char **target, char **ports, int *show_ope
 
 	if (*force_arp + *force_ping + *no_host_disc > 1)
 	{
-		fprintf(stderr, "[-] Conflicting options. Only one of -P, -a and -n can be used at once\n\n");
+		fprintf(stderr, "[-] Conflicting options. Only one of -P, -a and -n can be used at once\n");
 		usage(stderr);
 		return -1;
 	}
 
 	if (*target == NULL)
 	{
-		fprintf(stderr, "[-] No valid target specified\n\n");
+		fprintf(stderr, "[-] No valid target specified\n");
 		usage(stderr);
 		return -1;
 	}

--- a/src/error.c
+++ b/src/error.c
@@ -34,6 +34,6 @@ const char *const error_strings[] = {
 	"Error creating thread",
 	"An error occurred while getting source address",
 	"Address family not supported",
-	"Could not parse command line arguments"};
+	"Error during parse of command line arguments"};
 
 static_assert(ENUMS == COUNT, "Enums and err strings are not equal.\n");

--- a/src/error.c
+++ b/src/error.c
@@ -3,15 +3,15 @@
 
 #define ENUMS (sizeof(error_strings) / sizeof(error_strings[0]))
 
-void print_err(char *function, int err_val)
+void print_err(FILE *stream, char *function, int err_val)
 {
 	/* Don't care */
 	if (err_val == -1)
 	{
-		fprintf(stderr, "%s\n", function);
+		fprintf(stream, "%s\n", function);
 		return;
 	}
-	fprintf(stderr, "%s: %s\n", function, error_strings[err_val]);
+	fprintf(stream, "%s: %s\n", function, error_strings[err_val]);
 }
 
 const char *const error_strings[] = {

--- a/src/error.c
+++ b/src/error.c
@@ -33,6 +33,7 @@ const char *const error_strings[] = {
 	"pcap_loop error",
 	"Error creating thread",
 	"An error occurred while getting source address",
-	"Address family not supported"};
+	"Address family not supported",
+	"Could not parse command line arguments"};
 
 static_assert(ENUMS == COUNT, "Enums and err strings are not equal.\n");

--- a/src/main.c
+++ b/src/main.c
@@ -192,7 +192,6 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	// TODO Write port status. Open, closed, unknown?
 	// TODO Write results to file
 
 cleanup:

--- a/src/main.c
+++ b/src/main.c
@@ -90,9 +90,10 @@ int main(int argc, char *argv[])
 	int no_host_disc = 0;
 	int force_ping = 0;
 	int force_arp = 0;
+	int show_open = 0;
 	int rv = 0;
 
-	if (parse_cli(argc, argv, &target, &ports, &no_host_disc, &force_ping, &force_arp) != 0)
+	if (parse_cli(argc, argv, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp) != 0)
 	{
 		return CLI_PARSE;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,7 @@ int main(int argc, char *argv[])
 
 	char *ports = NULL;
 	char *target = NULL;
+	char *write_file = NULL;
 
 	unsigned short *port_arr = NULL;
 	unsigned short *res_arr = NULL;
@@ -107,7 +108,7 @@ int main(int argc, char *argv[])
 	int show_open = 0;
 	int rv = 0;
 
-	if (parse_cli(argc, argv, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp) != 0)
+	if (parse_cli(argc, argv, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp, &write_file) != 0)
 	{
 		return CLI_PARSE;
 	}
@@ -193,6 +194,7 @@ int main(int argc, char *argv[])
 	}
 
 	// TODO Write results to file
+	printf("[*] Writing results to file: %s\n", write_file);
 
 cleanup:
 	if (target != NULL)
@@ -210,6 +212,10 @@ cleanup:
 	if (res_arr != NULL)
 	{
 		free(res_arr);
+	}
+	if (write_file != NULL)
+	{
+		free(write_file);
 	}
 
 	return rv;

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,14 @@
 #define RETRIES 3
 #define MSG_BUF_SIZE 2048
 
+/**
+ * @brief Print a message to a stream and to a file if provided.
+ *
+ * @param stream e.g. `stderr` or `stdout`
+ * @param fp file pointer to an output file. Can be NULL.
+ * @param msg message to print
+ * @return int 0 on success, -1 if stream is NULL
+ */
 static int print_wrapper(FILE *stream, FILE *fp, const char *msg)
 {
 	if (stream == NULL)
@@ -28,6 +36,14 @@ static int print_wrapper(FILE *stream, FILE *fp, const char *msg)
 	return 0;
 }
 
+/**
+ * @brief Default host discovery function. First tries ARP, then falls back to
+ * ICMP if ARP fails.
+ *
+ * @param fp file pointer to an output file. Can be NULL.
+ * @param target The target address to check.
+ * @return `int` 0 on success, `NO_RESPONSE` if an error occurs.
+ */
 static int default_scan(FILE *fp, char *target)
 {
 	int rv = arp(target);
@@ -49,6 +65,15 @@ static int default_scan(FILE *fp, char *target)
 	return 0;
 }
 
+/**
+ * @brief Print open ports.
+ *
+ * @param res_arr Array of port scan results.
+ * @param port_arr Array of ports supplied by the user.
+ * @param port_count Number of ports in the user-supplied array.
+ * @param show_open Flag to indicate whether to show only open ports.
+ * @param fp File pointer to an output file. Can be NULL.
+ */
 static void print_open_ports(unsigned short *res_arr,
 							 unsigned short *port_arr,
 							 int port_count,

--- a/src/main.c
+++ b/src/main.c
@@ -93,7 +93,7 @@ static void print_open_ports(unsigned short *res_arr,
 	print_wrapper(stdout, fp, m);
 
 	int open_count = 0;
-	int unknown_count = 0;
+	int filtered_count = 0;
 	for (int i = 0; i < port_count; i++)
 	{
 		unsigned short port = port_arr[i];
@@ -104,15 +104,15 @@ static void print_open_ports(unsigned short *res_arr,
 			memset(msg_buf, 0, MSG_BUF_SIZE);
 			open_count++;
 		}
-		else if (res_arr[port] == UNKNOWN)
+		else if (res_arr[port] == FILTERED)
 		{
 			if (!show_open)
 			{
-				snprintf(msg_buf, MSG_BUF_SIZE, "%d\tunknown\n", port);
+				snprintf(msg_buf, MSG_BUF_SIZE, "%d\tfiltered\n", port);
 				print_wrapper(stdout, fp, msg_buf);
 				memset(msg_buf, 0, MSG_BUF_SIZE);
 			}
-			unknown_count++;
+			filtered_count++;
 		}
 	}
 
@@ -120,26 +120,26 @@ static void print_open_ports(unsigned short *res_arr,
 	{
 		if (!show_open)
 		{
-			snprintf(msg_buf, MSG_BUF_SIZE, "\n[+] Found %d open port(s), %d unknown port(s), %d closed port(s) not shown\n",
+			snprintf(msg_buf, MSG_BUF_SIZE, "\n[+] Found %d open port(s), %d filtered port(s), %d closed port(s) not shown\n",
 					 open_count,
-					 unknown_count,
-					 port_count - open_count - unknown_count);
+					 filtered_count,
+					 port_count - open_count - filtered_count);
 			print_wrapper(stdout, fp, msg_buf);
 			memset(msg_buf, 0, MSG_BUF_SIZE);
 		}
 		else
 		{
-			snprintf(msg_buf, MSG_BUF_SIZE, "\n[+] Found %d open port(s), %d unknown and %d closed port(s) not shown\n",
+			snprintf(msg_buf, MSG_BUF_SIZE, "\n[+] Found %d open port(s), %d filtered and %d closed port(s) not shown\n",
 					 open_count,
-					 unknown_count,
-					 port_count - open_count - unknown_count);
+					 filtered_count,
+					 port_count - open_count - filtered_count);
 			print_wrapper(stdout, fp, msg_buf);
 			memset(msg_buf, 0, MSG_BUF_SIZE);
 		}
 	}
 	else if (open_count == port_count)
 	{
-		m = "\n All scanned ports are open!\n";
+		m = "\n[+] All scanned ports are open!\n";
 		print_wrapper(stdout, fp, m);
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -261,11 +261,9 @@ int main(int argc, char *argv[])
 			goto cleanup;
 		}
 
-		msg = "[+] Port scan results:\n";
-		print_wrapper(stdout, fp, msg);
-
 		if (is_open_port)
 		{
+			print_wrapper(stdout, fp, "[+] Port scan results:\n");
 			print_open_ports(res_arr, port_arr, port_count, show_open, fp);
 		}
 		else

--- a/src/main.c
+++ b/src/main.c
@@ -74,9 +74,17 @@ int main(int argc, char *argv[])
 		printf("Host %s is up!\n", target);
 	}
 
+	if (ports == NULL && no_host_disc && !force_arp && !force_ping)
+	{
+		fprintf(stderr, "WARNING: Doing nothing. Use '-p' with the '-n' option!\n\n");
+		usage(stderr);
+		rv = CLI_PARSE;
+		goto cleanup;
+	}
+
 	if (no_host_disc)
 	{
-		printf("Skipping host discovery...\n");
+		printf("Skipping host status check...\n");
 	}
 
 	if (!no_host_disc && !force_arp && !force_ping)

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
 
 #define RETRIES 3
 
-int default_scan(char *target, char *ports)
+int default_scan(char *target)
 {
 	int rv = arp(target);
 	if (rv == SUCCESS)
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
 		usage(stdout);
 		return CLI_PARSE;
 	}
+
 	char *ports = NULL;
 	char *target = NULL;
 	int no_host_disc = 0;
@@ -78,7 +79,7 @@ int main(int argc, char *argv[])
 
 	if (!no_host_disc && !force_arp && !force_ping)
 	{
-		rv = default_scan(target, ports);
+		rv = default_scan(target);
 		if (rv != 0)
 		{
 			return rv;
@@ -98,8 +99,10 @@ int main(int argc, char *argv[])
 		if (rv != SUCCESS)
 		{
 			print_err("TCP SYN", rv);
+			free(port_arr);
 			return rv;
 		}
+		free(port_arr);
 	}
 
 	return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,72 @@
 #include <stdio.h>
-#include <stdlib.h>
+#include "../include/error.h"
+#include "../include/cli.h"
+#include "../include/arp.h"
 #include "../include/ping.h"
+#include "../include/syn_scan.h"
 
-// sample program
+int default_scan(char *target, char *ports)
+{
+	int rv = arp(target);
+	if (rv == SUCCESS)
+	{
+		printf("Host %s is up!\n", target);
+	}
+	else
+	{
+		rv = ping(target, 3);
+		if (rv != SUCCESS)
+		{
+			print_err("ARP/ping", rv);
+			return NO_RESPONSE;
+		}
+		printf("Host %s is up!\n", target);
+	}
+
+	if (ports != NULL)
+	{
+		int port_count = 0;
+		unsigned short *port_arr = parse_ports(ports, &port_count);
+		if (port_arr == NULL)
+		{
+			fprintf(stderr, "ERROR: an error occurred while parsing ports\n");
+			return -1;
+		}
+		rv = port_scan(target, port_arr, port_count, 1 /*Print state*/, NULL /*Return Array of Results*/);
+		if (rv != SUCCESS)
+		{
+			print_err("TCP SYN", rv);
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 int main(int argc, char *argv[])
 {
+	if (argc == 1)
+	{
+		usage(stdout);
+		return CLI_PARSE;
+	}
+	char *ports = NULL;
+	char *target = NULL;
+	int no_host_disc = 0;
+	int force_ping = 0;
+	int force_arp = 0;
+	int rv = 0;
+
+	if (parse_cli(argc, argv, &target, &ports, &no_host_disc, &force_ping, &force_arp) != 0)
+	{
+		return CLI_PARSE;
+	}
+
+	rv = default_scan(target, ports);
+	if (rv != 0)
+	{
+		return rv;
+	}
+
+	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -5,30 +5,4 @@
 // sample program
 int main(int argc, char *argv[])
 {
-	if (argc != 3)
-	{
-		printf("Provide an IP as the first argument and the number of pings as the second\n");
-		return -1;
-	}
-
-	printf("Pinging %s\n", argv[1]);
-	int ret = ping(argv[1], atoi(argv[2]));
-	switch (ret)
-	{
-	case 0:
-		printf("Host is up!\n");
-		return ret;
-		break;
-	case 1:
-		printf("No response from host.\n");
-		break;
-	case 2:
-		printf("Invalid IP address.\n");
-		return ret;
-		break;
-	default:
-		printf("Some error occurred.");
-		return ret;
-		break;
-	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,9 @@ static void print_open_ports(unsigned short *res_arr,
 	}
 
 	printf("\nPORT\tSTATE\n");
+
 	int open_count = 0;
+	int unknown_count = 0;
 	for (int i = 0; i < port_count; i++)
 	{
 		unsigned short port = port_arr[i];
@@ -51,13 +53,19 @@ static void print_open_ports(unsigned short *res_arr,
 			printf("%d\topen\n", port);
 			open_count++;
 		}
+		else if (res_arr[port] == UNKNOWN)
+		{
+			printf("%d\tunknown\n", port);
+			unknown_count++;
+		}
 	}
 
 	if (open_count != port_count)
 	{
-		printf("\n[+] Found %d open port(s), %d closed port(s) not shown\n",
+		printf("\n[+] Found %d open port(s), %d unknown port(s), %d closed port(s) not shown\n",
 			   open_count,
-			   port_count - open_count);
+			   unknown_count,
+			   port_count - open_count - unknown_count);
 	}
 	else if (open_count == port_count)
 	{

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+#include <stdlib.h>
+
 #include "../include/error.h"
 #include "../include/cli.h"
 #include "../include/arp.h"
@@ -55,7 +57,7 @@ int main(int argc, char *argv[])
 		if (rv != SUCCESS)
 		{
 			print_err("ARP", rv);
-			return rv;
+			goto cleanup;
 		}
 		printf("Host %s is up!\n", target);
 	}
@@ -67,7 +69,7 @@ int main(int argc, char *argv[])
 		if (rv != SUCCESS)
 		{
 			print_err("Ping", rv);
-			return rv;
+			goto cleanup;
 		}
 		printf("Host %s is up!\n", target);
 	}
@@ -82,7 +84,7 @@ int main(int argc, char *argv[])
 		rv = default_scan(target);
 		if (rv != 0)
 		{
-			return rv;
+			goto cleanup;
 		}
 	}
 
@@ -93,17 +95,28 @@ int main(int argc, char *argv[])
 		if (port_arr == NULL)
 		{
 			fprintf(stderr, "ERROR: an error occurred while parsing ports\n");
-			return CLI_PARSE;
+			rv = CLI_PARSE;
+			goto cleanup;
 		}
 		rv = port_scan(target, port_arr, port_count, 1 /*Print state*/, NULL /*Return Array of Results*/);
 		if (rv != SUCCESS)
 		{
 			print_err("TCP SYN", rv);
 			free(port_arr);
-			return rv;
+			goto cleanup;
 		}
 		free(port_arr);
 	}
 
-	return 0;
+cleanup:
+	if (target != NULL)
+	{
+		free(target);
+	}
+	if (ports != NULL)
+	{
+		free(ports);
+	}
+
+	return rv;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
 
 #include "../include/error.h"
 #include "../include/cli.h"
@@ -146,6 +148,14 @@ int main(int argc, char *argv[])
 	if (parse_cli(argc, argv, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp, &write_file) != 0)
 	{
 		return CLI_PARSE;
+	}
+
+	if (getuid() != 0)
+	{
+		fprintf(stderr, "[-] Permission denied, run as root!\n");
+		usage(stderr);
+		rv = PERMISSION_ERROR;
+		goto cleanup;
 	}
 
 	if (write_file != NULL)

--- a/src/main.c
+++ b/src/main.c
@@ -95,7 +95,8 @@ int main(int argc, char *argv[])
 		rv = arp(target);
 		if (rv != SUCCESS)
 		{
-			print_err("[-] arp", rv);
+			fprintf(stderr, "[-] ARP failed, try with '-P' instead\n\n");
+			usage(stderr);
 			goto cleanup;
 		}
 		printf("[+] Host %s is up!\n", target);
@@ -155,6 +156,8 @@ int main(int argc, char *argv[])
 			print_err("[-] port_scan", rv);
 			goto cleanup;
 		}
+
+		printf("[+] Port scan results:\n");
 
 		if (is_open_port)
 		{

--- a/src/main.c
+++ b/src/main.c
@@ -108,7 +108,8 @@ int main(int argc, char *argv[])
 			goto cleanup;
 		}
 		printf("[*] Scanning %d port(s) on %s...\n", port_count, target);
-		rv = port_scan(target, port_arr, port_count, 1 /*Print state*/, NULL /*Return Array of Results*/);
+		short is_open_port = 0;
+		rv = port_scan(target, port_arr, port_count, &is_open_port, NULL /*Return Array of Results*/);
 		if (rv != SUCCESS)
 		{
 			print_err("[-] port_scan", rv);

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,8 @@ static int default_scan(char *target)
 
 static void print_open_ports(unsigned short *res_arr,
 							 unsigned short *port_arr,
-							 int port_count)
+							 int port_count,
+							 int show_open)
 {
 	if (res_arr == NULL || port_arr == NULL)
 	{
@@ -55,17 +56,30 @@ static void print_open_ports(unsigned short *res_arr,
 		}
 		else if (res_arr[port] == UNKNOWN)
 		{
-			printf("%d\tunknown\n", port);
+			if (!show_open)
+			{
+				printf("%d\tunknown\n", port);
+			}
 			unknown_count++;
 		}
 	}
 
 	if (open_count != port_count)
 	{
-		printf("\n[+] Found %d open port(s), %d unknown port(s), %d closed port(s) not shown\n",
-			   open_count,
-			   unknown_count,
-			   port_count - open_count - unknown_count);
+		if (!show_open)
+		{
+			printf("\n[+] Found %d open port(s), %d unknown port(s), %d closed port(s) not shown\n",
+				   open_count,
+				   unknown_count,
+				   port_count - open_count - unknown_count);
+		}
+		else
+		{
+			printf("\n[+] Found %d open port(s), %d unknown and %d closed port(s) not shown\n",
+				   open_count,
+				   unknown_count,
+				   port_count - open_count - unknown_count);
+		}
 	}
 	else if (open_count == port_count)
 	{
@@ -170,7 +184,7 @@ int main(int argc, char *argv[])
 
 		if (is_open_port)
 		{
-			print_open_ports(res_arr, port_arr, port_count);
+			print_open_ports(res_arr, port_arr, port_count, show_open);
 		}
 		else
 		{

--- a/src/syn_scan.c
+++ b/src/syn_scan.c
@@ -36,9 +36,6 @@
 #define ETH_TYPE_IPV6 0x86DD
 #define IP_PROTO_TCP 0x06
 #define REALLOC_SIZE 1024
-#define UNKNOWN 0
-#define OPEN 1
-#define CLOSED 2
 #define CHECKSUM_LEN_IPV4 (sizeof(tcp_header_t) + sizeof(tcp_pseudo_ipv4_t))
 #define CHECKSUM_LEN_IPV6 (sizeof(tcp_header_t) + sizeof(tcp_pseudo_ipv6_t))
 
@@ -840,7 +837,11 @@ static int send_syn(int sfd,
 	return 0;
 }
 
-int port_scan(char *address, unsigned short *port_arr, int port_count, short *is_open_port, short **result_arr)
+int port_scan(char *address,
+			  unsigned short *port_arr,
+			  int port_count,
+			  short *is_open_port,
+			  unsigned short **result_arr)
 {
 	if (test_print)
 	{
@@ -1078,10 +1079,11 @@ int port_scan(char *address, unsigned short *port_arr, int port_count, short *is
 	/* Save results to supplied result_arr for use in caller */
 	if (result_arr != NULL)
 	{
-		*result_arr = malloc(65536 * sizeof(short));
+		*result_arr = malloc(65536 * sizeof(unsigned short));
 		if (*result_arr != NULL)
 		{
-			memcpy(*result_arr, (short *)c_data.port_status, 65536 * sizeof(short));
+			memcpy(*result_arr, (unsigned short *)c_data.port_status,
+				   65536 * sizeof(unsigned short));
 		}
 	}
 

--- a/src/syn_scan.c
+++ b/src/syn_scan.c
@@ -798,7 +798,7 @@ static int send_syn(int sfd,
 			}
 
 			/* Skip if port has already responded (open or closed) */
-			if (c_data->port_status[port_arr[p_index]] != UNKNOWN)
+			if (c_data->port_status[port_arr[p_index]] != FILTERED)
 			{
 				continue;
 			}

--- a/src/syn_scan.c
+++ b/src/syn_scan.c
@@ -66,6 +66,7 @@ struct src_info
 struct callback_data
 {
 	short loopback_flag;
+	short any_open; /* Flag if any open port is found */
 	volatile short port_status[65536];
 };
 
@@ -167,6 +168,7 @@ static void tcp_process_pkt(u_char *user, const struct pcap_pkthdr *pkt_hdr,
 	if (tcp_hdr->flags == SYN_ACK)
 	{
 		c_data->port_status[ntohs(tcp_hdr->sport)] = OPEN;
+		c_data->any_open = 1;
 	}
 	else if (tcp_hdr->flags & RST)
 	{
@@ -838,7 +840,7 @@ static int send_syn(int sfd,
 	return 0;
 }
 
-int port_scan(char *address, unsigned short *port_arr, int port_count, int print_state, short **result_arr)
+int port_scan(char *address, unsigned short *port_arr, int port_count, short *is_open_port, short **result_arr)
 {
 	if (test_print)
 	{
@@ -1070,6 +1072,8 @@ int port_scan(char *address, unsigned short *port_arr, int port_count, int print
 		}
 		printf("│ %d ports are closed\n", port_count - open_count);
 	}
+
+	*is_open_port = c_data.any_open;
 
 	/* Save results to supplied result_arr for use in caller */
 	if (result_arr != NULL)

--- a/tests/arp_test.c
+++ b/tests/arp_test.c
@@ -42,20 +42,20 @@ void arp_test(void)
 	if ((ret = arp_possible_test("8.8.8.8")) == ARP_NOT_SUPP)
 		printf("✅ Remote IP 8.8.8.8 does not support ARP test: Passed\n");
 	else
-		print_err("❌ Remote IP 8.8.8.8 does not support ARP test failed", ret);
+		print_err(stderr, "❌ Remote IP 8.8.8.8 does not support ARP test failed", ret);
 
 	if ((ret = arp_possible_test("192.168.1.1")) == ARP_SUPP)
 		printf("✅ Local live host 192.168.1.1 supports ARP test: Passed\n");
 	else
-		print_err("❌ Local live host 192.168.1.1 supports ARP test failed", ret);
+		print_err(stderr, "❌ Local live host 192.168.1.1 supports ARP test failed", ret);
 
 	if ((ret = arp("192.168.1.1")) == SUCCESS)
 		printf("✅ ARP request to live host 192.168.1.1 received reply test: Passed\n");
 	else
-		print_err("❌ ARP request to live host 192.168.1.1 received reply test failed", ret);
+		print_err(stderr, "❌ ARP request to live host 192.168.1.1 received reply test failed", ret);
 
 	if ((ret = arp("192.168.1.100")) == NO_RESPONSE)
 		printf("✅ ARP request to down host 192.168.1.100 received no reply test: Passed\n");
 	else
-		print_err("❌ ARP request to down host 192.168.1.100 received no reply test failed", ret);
+		print_err(stderr, "❌ ARP request to down host 192.168.1.100 received no reply test failed", ret);
 }

--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -6,7 +6,17 @@ void cli_test(void)
 {
 	printf("-- CLI TESTS --\n");
 
-	char *parse[] = {"program", "-p", "80,443", "invalid", "127.0.0.1", "::1", NULL};
+	char *help[] = {"program", "-h", NULL};
+	char *parse[] = {"program",
+					 "-p",
+					 "80,443",
+					 "--no-check",
+					 "-P",
+					 "-a",
+					 "invalid",
+					 "127.0.0.1",
+					 "::1", NULL};
 
-	parse_cli(6, parse);
+	parse_cli(2, help);
+	parse_cli(9, parse);
 }

--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include "../include/cli.h"
+#include "../include/error.h"
+
+void cli_test(void)
+{
+	printf("-- CLI TESTS --\n");
+
+	char *port_test[] = {"program", "-p", "80,443", NULL};
+
+	parse_cli(3, port_test);
+}

--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -1,12 +1,66 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "../include/cli.h"
 #include "../include/error.h"
+
+static void test(int number_of_flags, char *ports, char *target, int no_host_disc, int force_ping, int force_arp)
+{
+	int set = 0;
+	if (ports)
+	{
+		set++;
+	}
+
+	if (target)
+	{
+		set++;
+	}
+
+	if (no_host_disc)
+	{
+		set++;
+	}
+
+	if (force_ping)
+	{
+		set++;
+	}
+
+	if (force_arp)
+	{
+		set++;
+	}
+
+	if (number_of_flags)
+	{
+		if (set == number_of_flags)
+		{
+			printf("✅ Set all options test: passed\n");
+			return;
+		}
+		printf("❌ Set all options test: failed\n");
+		return;
+	}
+
+	if (set == number_of_flags)
+	{
+		printf("✅ Usage flag test: passed\n");
+		return;
+	}
+	printf("❌ Usage flag test: failed\n");
+}
 
 void cli_test(void)
 {
 	printf("-- CLI TESTS --\n");
 
-	char *help[] = {"program", "-h", NULL};
+	char *ports = NULL;
+	char *target = NULL;
+	int no_host_disc = 0;
+	int force_ping = 0;
+	int force_arp = 0;
+
+	char *help[] = {"program", "-h"};
 	char *parse[] = {"program",
 					 "-p",
 					 "80,443",
@@ -15,8 +69,16 @@ void cli_test(void)
 					 "-a",
 					 "invalid",
 					 "127.0.0.1",
-					 "::1", NULL};
+					 "::1"};
 
-	parse_cli(2, help);
-	parse_cli(9, parse);
+	parse_cli(2, help, &target, &ports, &no_host_disc, &force_ping, &force_arp);
+
+	test(0, ports, target, no_host_disc, force_ping, force_arp);
+
+	parse_cli(10, parse, &target, &ports, &no_host_disc, &force_ping, &force_arp);
+
+	test(5, ports, target, no_host_disc, force_ping, force_arp);
+
+	free(ports);
+	free(target);
 }

--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -3,10 +3,15 @@
 #include "../include/cli.h"
 #include "../include/error.h"
 
-static void test(int number_of_flags, char *ports, char *target, int no_host_disc, int force_ping, int force_arp)
+static void test(int number_of_flags, char *ports, int show_open, char *target, int no_host_disc, int force_ping, int force_arp)
 {
 	int set = 0;
 	if (ports)
+	{
+		set++;
+	}
+
+	if (show_open)
 	{
 		set++;
 	}
@@ -59,6 +64,7 @@ void cli_test(void)
 	int no_host_disc = 0;
 	int force_ping = 0;
 	int force_arp = 0;
+	int show_open = 0;
 
 	char *help[] = {"program", "-h"};
 	char *parse[] = {"program",
@@ -66,18 +72,19 @@ void cli_test(void)
 					 "80,443",
 					 "--no-check",
 					 "-P",
+					 "-o",
 					 "-a",
 					 "invalid",
 					 "127.0.0.1",
 					 "::1"};
 
-	parse_cli(2, help, &target, &ports, &no_host_disc, &force_ping, &force_arp);
+	parse_cli(2, help, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp);
 
-	test(0, ports, target, no_host_disc, force_ping, force_arp);
+	test(0, ports, 0, target, no_host_disc, force_ping, force_arp);
 
-	parse_cli(10, parse, &target, &ports, &no_host_disc, &force_ping, &force_arp);
+	parse_cli(11, parse, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp);
 
-	test(5, ports, target, no_host_disc, force_ping, force_arp);
+	test(6, ports, 1, target, no_host_disc, force_ping, force_arp);
 
 	free(ports);
 	free(target);

--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -6,7 +6,7 @@ void cli_test(void)
 {
 	printf("-- CLI TESTS --\n");
 
-	char *port_test[] = {"program", "-p", "80,443", NULL};
+	char *parse[] = {"program", "-p", "80,443", "invalid", "127.0.0.1", "::1", NULL};
 
-	parse_cli(3, port_test);
+	parse_cli(6, parse);
 }

--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -78,11 +78,11 @@ void cli_test(void)
 					 "127.0.0.1",
 					 "::1"};
 
-	parse_cli(2, help, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp);
+	parse_cli(2, help, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp, NULL);
 
 	test(0, ports, 0, target, no_host_disc, force_ping, force_arp);
 
-	parse_cli(11, parse, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp);
+	parse_cli(11, parse, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp, NULL);
 
 	test(6, ports, 1, target, no_host_disc, force_ping, force_arp);
 

--- a/tests/include/cli_test.h
+++ b/tests/include/cli_test.h
@@ -1,0 +1,6 @@
+#ifndef CLI_TEST_H
+#define CLI_TEST_H
+
+void cli_test(void);
+
+#endif

--- a/tests/ping_test.c
+++ b/tests/ping_test.c
@@ -9,45 +9,45 @@ void ping_test(void)
 	if ((ret = ping("256.1.1.1", 3)) == UNKNOWN_HOST)
 		printf("✅ IPv4 invalid IP test: Passed\n");
 	else
-		print_err("❌ IPv4 invalid IP test failed", ret);
+		print_err(stderr, "❌ IPv4 invalid IP test failed", ret);
 
 	if ((ret = ping("2001:0db8::85a3::8a2e:0370:7334", 3)) == UNKNOWN_HOST)
 		printf("✅ IPv6 invalid IP test: Passed\n");
 	else
-		print_err("❌ IPv6 invalid IP test failed", ret);
+		print_err(stderr, "❌ IPv6 invalid IP test failed", ret);
 
 	if ((ret = ping("127.0.0.1", 3)) == SUCCESS)
 		printf("✅ IPv4 loopback ping test: Passed\n");
 	else
-		print_err("❌ IPv4 loopback ping test failed", ret);
+		print_err(stderr, "❌ IPv4 loopback ping test failed", ret);
 
 	if ((ret = ping("::1", 3)) == SUCCESS)
 		printf("✅ IPv6 loopback ping test: Passed\n");
 	else
-		print_err("❌ IPv6 loopback ping test failed", ret);
+		print_err(stderr, "❌ IPv6 loopback ping test failed", ret);
 
 	if ((ret = ping("93.184.215.14", 3)) == SUCCESS)
 		printf("✅ IPv4 IP of example.com ping test: Passed\n");
 	else
-		print_err("❌ IPv4 IP of example.com ping test failed", ret);
+		print_err(stderr, "❌ IPv4 IP of example.com ping test failed", ret);
 
 	if ((ret = ping("2606:2800:21f:cb07:6820:80da:af6b:8b2c", 3)) == SUCCESS)
 		printf("✅ IPv6 IP of example.com ping test: Passed\n");
 	else
-		print_err("❌ IPv6 IP of example.com ping test failed", ret);
+		print_err(stderr, "❌ IPv6 IP of example.com ping test failed", ret);
 
 	if ((ret = ping("example.com", 3)) == SUCCESS)
 		printf("✅ Valid domain name 'example.com' ping test: Passed\n");
 	else
-		print_err("❌ Valid domain name 'example.com' ping test failed", ret);
+		print_err(stderr, "❌ Valid domain name 'example.com' ping test failed", ret);
 
 	if ((ret = ping("example.xyz", 3)) == UNKNOWN_HOST)
 		printf("✅ Invalid domain name 'example.xyz' ping test: Passed\n");
 	else
-		print_err("❌ Invalid domain name 'example.xyz' ping test failed", ret);
+		print_err(stderr, "❌ Invalid domain name 'example.xyz' ping test failed", ret);
 
 	if ((ret = ping("3fff:fff:ffff:ffff:ffff:ffff:ffff:ffff", 3)) == NO_RESPONSE)
 		printf("✅ IPv6 unreachable address ping test: Passed\n");
 	else
-		print_err("❌ IPv6 unreachable address ping test failed", ret);
+		print_err(stderr, "❌ IPv6 unreachable address ping test failed", ret);
 }

--- a/tests/run_all_tests.c
+++ b/tests/run_all_tests.c
@@ -3,6 +3,7 @@
 #include "include/arp_test.h"
 #include "include/ping_test.h"
 #include "include/syn_scan_test.h"
+#include "include/cli_test.h"
 
 int main(void)
 {
@@ -11,6 +12,8 @@ int main(void)
 	arp_test();
 	printf("\n");
 	syn_scan_test();
+	printf("\n");
+	cli_test();
 
 	return 0;
 }

--- a/tests/syn_scan_test.c
+++ b/tests/syn_scan_test.c
@@ -69,49 +69,51 @@ void syn_scan_test(void)
 		print_err("❌ Parse mixed ports failed", -1);
 	}
 
-	if ((ret = port_scan("127.0.0.1", test_arr, TEST_ARR_LEN, 1, NULL)) == SUCCESS)
+	short is_open = 0;
+
+	if ((ret = port_scan("127.0.0.1", test_arr, TEST_ARR_LEN, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ Localhost IPv4 Port scan test: Passed\n");
 	else
 	{
 		print_err("└ ❌ Localhost IPv4 Port scan test failed", ret);
 	}
 
-	if ((ret = port_scan("::1", test_arr, TEST_ARR_LEN, 1, NULL)) == SUCCESS)
+	if ((ret = port_scan("::1", test_arr, TEST_ARR_LEN, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ Localhost IPv6 Port scan test: Passed\n");
 	else
 	{
 		print_err("└ ❌ Localhost IPv6 Port scan test failed", ret);
 	}
 
-	if ((ret = port_scan("127.0.0.1", all_ports, all_port_count, 1, NULL)) == SUCCESS)
+	/*if ((ret = port_scan("127.0.0.1", all_ports, all_port_count, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ IPv4 Localhost full port scan test: Passed\n");
 	else
 	{
 		print_err("└ ❌ IPv4 Localhost full port scan test failed", ret);
 	}
 
-	if ((ret = port_scan("::1", all_ports, all_port_count, 1, NULL)) == SUCCESS)
+	if ((ret = port_scan("::1", all_ports, all_port_count, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ IPv6 Localhost full port scan test: Passed\n");
 	else
 	{
 		print_err("└ ❌ IPv6 Localhost full port scan test failed", ret);
-	}
+	}*/
 
 	if (ping(lan_dev, 3) == SUCCESS)
 	{
-		if ((ret = port_scan(lan_dev, test_arr, TEST_ARR_LEN, 1, NULL)) == SUCCESS)
+		if ((ret = port_scan(lan_dev, test_arr, TEST_ARR_LEN, &is_open, NULL)) == SUCCESS)
 			printf("└ ✅ IPv4 LAN device port scan test: Passed\n");
 		else
 		{
 			print_err("└ ❌ IPv4 LAN device port scan test failed", ret);
 		}
 
-		if ((ret = port_scan(lan_dev, all_ports, all_port_count, 1, NULL)) == SUCCESS)
+		/*if ((ret = port_scan(lan_dev, all_ports, all_port_count, &is_open, NULL)) == SUCCESS)
 			printf("└ ✅ IPv4 LAN device full port scan test: Passed\n");
 		else
 		{
 			print_err("└ ❌ IPv4 LAN device full port scan test failed", ret);
-		}
+		}*/
 	}
 	else
 	{
@@ -126,7 +128,7 @@ void syn_scan_test(void)
 		print_err("❌ IPv6 Lan Port scan test failed", ret);
 	}*/
 
-	if ((ret = port_scan("scanme.nmap.org", scanme_ports, 4, 1, NULL)) == SUCCESS)
+	if ((ret = port_scan("scanme.nmap.org", scanme_ports, 4, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ External Port scan test: Passed\n");
 	else
 	{

--- a/tests/syn_scan_test.c
+++ b/tests/syn_scan_test.c
@@ -34,7 +34,7 @@ void syn_scan_test(void)
 		{
 			if (all_ports[i] != i + 1)
 			{
-				print_err("❌ Parse all ports failed", -1);
+				print_err(stderr, "❌ Parse all ports failed", -1);
 				break;
 			}
 		}
@@ -42,7 +42,7 @@ void syn_scan_test(void)
 	}
 	else
 	{
-		print_err("❌ Parse all ports test failed", -1);
+		print_err(stderr, "❌ Parse all ports test failed", -1);
 	}
 
 	int parse_ok = 1;
@@ -54,7 +54,7 @@ void syn_scan_test(void)
 		{
 			if (parse_test_arr[i] != parse_test_ports[i])
 			{
-				print_err("❌ Parse mixed ports test failed", -1);
+				print_err(stderr, "❌ Parse mixed ports test failed", -1);
 				parse_ok = 0;
 				break;
 			}
@@ -66,7 +66,7 @@ void syn_scan_test(void)
 	}
 	else
 	{
-		print_err("❌ Parse mixed ports failed", -1);
+		print_err(stderr, "❌ Parse mixed ports failed", -1);
 	}
 
 	short is_open = 0;
@@ -75,28 +75,28 @@ void syn_scan_test(void)
 		printf("└ ✅ Localhost IPv4 Port scan test: Passed\n");
 	else
 	{
-		print_err("└ ❌ Localhost IPv4 Port scan test failed", ret);
+		print_err(stderr, "└ ❌ Localhost IPv4 Port scan test failed", ret);
 	}
 
 	if ((ret = port_scan("::1", test_arr, TEST_ARR_LEN, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ Localhost IPv6 Port scan test: Passed\n");
 	else
 	{
-		print_err("└ ❌ Localhost IPv6 Port scan test failed", ret);
+		print_err(stderr, "└ ❌ Localhost IPv6 Port scan test failed", ret);
 	}
 
 	/*if ((ret = port_scan("127.0.0.1", all_ports, all_port_count, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ IPv4 Localhost full port scan test: Passed\n");
 	else
 	{
-		print_err("└ ❌ IPv4 Localhost full port scan test failed", ret);
+		print_err(stderr, "└ ❌ IPv4 Localhost full port scan test failed", ret);
 	}
 
 	if ((ret = port_scan("::1", all_ports, all_port_count, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ IPv6 Localhost full port scan test: Passed\n");
 	else
 	{
-		print_err("└ ❌ IPv6 Localhost full port scan test failed", ret);
+		print_err(stderr, "└ ❌ IPv6 Localhost full port scan test failed", ret);
 	}*/
 
 	if (ping(lan_dev, 3) == SUCCESS)
@@ -105,14 +105,14 @@ void syn_scan_test(void)
 			printf("└ ✅ IPv4 LAN device port scan test: Passed\n");
 		else
 		{
-			print_err("└ ❌ IPv4 LAN device port scan test failed", ret);
+			print_err(stderr, "└ ❌ IPv4 LAN device port scan test failed", ret);
 		}
 
 		/*if ((ret = port_scan(lan_dev, all_ports, all_port_count, &is_open, NULL)) == SUCCESS)
 			printf("└ ✅ IPv4 LAN device full port scan test: Passed\n");
 		else
 		{
-			print_err("└ ❌ IPv4 LAN device full port scan test failed", ret);
+			print_err(stderr, "└ ❌ IPv4 LAN device full port scan test failed", ret);
 		}*/
 	}
 	else
@@ -125,14 +125,14 @@ void syn_scan_test(void)
 		printf("✅ IPv6 Lan Port scan test: Passed\n");
 	else
 	{
-		print_err("❌ IPv6 Lan Port scan test failed", ret);
+		print_err(stderr, "❌ IPv6 Lan Port scan test failed", ret);
 	}*/
 
 	if ((ret = port_scan("scanme.nmap.org", scanme_ports, 4, &is_open, NULL)) == SUCCESS)
 		printf("└ ✅ External Port scan test: Passed\n");
 	else
 	{
-		print_err("└ ❌ External Port scan test failed", ret);
+		print_err(stderr, "└ ❌ External Port scan test failed", ret);
 	}
 
 	free(all_ports);

--- a/tests/syn_scan_test.c
+++ b/tests/syn_scan_test.c
@@ -10,6 +10,8 @@ void syn_scan_test(void)
 {
 	printf("-- SYN SCAN TESTS --\n");
 
+	set_test_print_flag(1);
+
 	/* DEBUG: sudo lsof -PiTCP -sTCP:LISTEN */
 
 	unsigned short parse_test_arr[10] = {1, 2, 3, 4, 5, 6, 10, 11, 4444, 65535};


### PR DESCRIPTION
# Add CLI Parsing and Core Program Logic
Add parsing of command-line arguments and `main`-logic to allow users to run the program. Supports various options like writing output to a file or specifying the host discovery mode.

Closes #7.

## CLI
- Show usage-message with mandatory and optional parameters
- Support for both short and long arguments, i.e., `-p` `--ports`
- Fine-grained control over host discovery methods with `-a` and `-P`
- Write output to a file of choice for documentation
- Handle conflicting options or argument errors

### New Files
- `src/cli.c` - Main parsing function
- `include/cli.h`- Header file with public CLI functions
- `tests/cli_test.c` 
	- Test `usage` flag (`-h`)
	- Test setting all options to ensure working parser

## Main
- Implement main logic for running Disco
- Control host discovery methods
- Parse ports and run SYN scan if any ports are supplied
- Print information and results to `stdout`
- Write output to a file if specified
- Centralized resource cleanup

### Usage Examples
```bash
# Basic scan
sudo ./bin/disco scanme.nmap.org -p 22,80,443

# Skip ARP since we know host is not reachable via ARP
sudo ./bin/disco scanme.nmap.org -p 22,80,443 -P

# Check if host is up and write results to a file
sudo ./bin/disco scanme.nmap.org -w output.txt
```

## File Changes
- `src/main.c` 
	- Core program logic
- `include/headers.h`
	- Move ARP packet headers from `include/arp.h` for a centralized packet header file.
	- Add TCP packet header and TCP IPv4 and IPv6 pseudo packet headers.
- `include/error.h` and `src/error.c`
	- Add CLI-related error code and description
	- Update `print_err` prototype and description
- `include/syn_scan.h` and `src/syn_scan.c`
	- Move port state definitions to header file
	- Add global flag for test-specific print statements
	- Add flag to indicate whether any open ports are found to caller
	- Store port statuses in caller-supplied array
- `tests/ping_test.c`, `tests/arp_test.c` and `tests/syn_scan_test.c`
	- Update functions calls to handle new parameters
- `tests/run_all_tests.c`
	- Add CLI tests to test run

## Tests
Run tests with `make test`. Program banner and error message when all CLI options are used should trigger at the end of test run. This is expected behavior.
