### PR TITLE
Fix External Hosts not Responding to SYN Scan

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -11,7 +11,10 @@ void print_err(FILE *stream, char *function, int err_val)
 		fprintf(stream, "%s\n", function);
 		return;
 	}
-	fprintf(stream, "%s: %s\n", function, error_strings[err_val]);
+	if (stream != NULL)
+	{
+		fprintf(stream, "%s: %s\n", function, error_strings[err_val]);
+	}
 }
 
 const char *const error_strings[] = {

--- a/src/syn_scan.c
+++ b/src/syn_scan.c
@@ -529,10 +529,14 @@ static int pcap_handle_setup(pcap_t **h, struct src_info src_info)
 			if (a->addr && a->addr->sa_family == AF_INET)
 			{
 				struct sockaddr_in *sin = (struct sockaddr_in *)a->addr;
-				if (strcmp(inet_ntoa(sin->sin_addr), if_ip) == 0)
+				char ipv4_str[INET_ADDRSTRLEN];
+				if (inet_ntop(AF_INET, &sin->sin_addr, ipv4_str, INET_ADDRSTRLEN))
 				{
-					if_name = d;
-					break;
+					if (strcmp(ipv4_str, if_ip) == 0)
+					{
+						if_name = d;
+						break;
+					}
 				}
 			}
 			else if (a->addr && a->addr->sa_family == AF_INET6)

--- a/src/syn_scan.c
+++ b/src/syn_scan.c
@@ -854,11 +854,12 @@ int port_scan(char *address,
 		return UNKNOWN_HOST;
 	}
 
-	/* Resolve address if domain*/
 	char resolved_address[INET6_ADDRSTRLEN];
 	if (dst->ai_addr->sa_family == AF_INET)
 	{
-		address = inet_ntoa(((struct sockaddr_in *)dst->ai_addr)->sin_addr);
+		inet_ntop(AF_INET, &((struct sockaddr_in *)dst->ai_addr)->sin_addr,
+				  resolved_address, INET_ADDRSTRLEN);
+		address = resolved_address;
 	}
 	else
 	{


### PR DESCRIPTION
# Fix External Hosts not Responding to TCP SYN
Fix bug where packets were routed correctly, but the replies never reached the program.

Partially closes #13. External IPv6 tests are not possible as per [comment](https://github.com/pilsnerfrajz/disco/issues/15#issuecomment-3262311008) in #15.

## TCP SYN
The issue was likely due to some buffer weirdness when using multiple calls to `inet_ntoa()`. Now, `inet_ntop()` is used for both IPv4 and IPv6, after reading [Beej's Guide](https://beej.us/guide/bgnet/html/split-wide/ip-addresses-structs-and-data-munging.html), which seems to have solved the issue. 

## File Changes
- `src/syn_scan.c` 
	- Change all occurrences of `inet_ntoa()`
- `src/error.c`
	- Fix root of segmentation fault when error during scan occurs

## Testing
Output shows that the program is working correctly but either the target or network is unstable, seeing as both of these ports should be open. 
```bash
sudo ./bin/disco scanme.nmap.org -p 22,80
[!] ARP failed, falling back to ICMP
[+] Host scanme.nmap.org is up!
[*] Scanning 5 port(s) on scanme.nmap.org...
[+] Port scan results:

PORT    STATE
22      open
80      filtered

[+] Found 1 open port(s), 1 filtered port(s), 3 closed port(s) not shown
```
