### PR TITLE
Add CI Workflow to Test Build

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,28 @@
+name: Build Test
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+          fetch-depth: 0
+          
+    - name: Compile
+      run: make
+
+  arm-build: 
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+          fetch-depth: 0
+          
+    - name: Compile
+      run: make

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -12,7 +12,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
           fetch-depth: 0
-          
+    
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y libpcap-dev
+    
     - name: Compile
       run: make
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OBJS := $(notdir $(patsubst %.c,%.o, $(wildcard $(SRC_DIR)/*.c)))
 TEST_OBJS := $(notdir $(patsubst %.c,%.o, $(wildcard $(TESTS_DIR)/*.c)))
 
 CC := gcc
-CFLAGS := -Wall -Wextra -pedantic
+CFLAGS := -Wall -Wextra -pedantic -Werror
 LDFLAGS := -lpcap -lpthread
 
 $(NAME): dir $(OBJS)


### PR DESCRIPTION
# Add CI Workflow to Test Build
Use Github Actions to automatically check for any compiler warnings or errors when creating a PR or when pushing code to the PR branch. This ensures that the program builds correctly on both Linux and macOS before it is merged into the main branch. 

## File Changes
- `Makefile` 
	- Add `-Werror` compiler flag to convert warnings into errors and fail the build
- `.github/workflows/makefile.yml`
	- Add build jobs for both Ubuntu and macOS runners
	- Install dependencies to ensure Ubuntu has `libpcap` installed
	- Trigger on pull requests to the main branch