### PR TITLE
Fix Segmentation Fault in CLI Test 

### DIFF
--- a/tests/cli_test.c
+++ b/tests/cli_test.c
@@ -81,13 +81,15 @@ void cli_test(void)
 					 "::1"};
 
 	parse_cli(2, help, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp, &force_syn, &file);
+	free(file);
 
 	test(0, ports, 0, target, no_host_disc, force_ping, force_arp);
-
+	file = NULL;
 	parse_cli(11, parse, &target, &ports, &show_open, &no_host_disc, &force_ping, &force_arp, &force_syn, &file);
 
 	test(6, ports, 1, target, no_host_disc, force_ping, force_arp);
 
 	free(ports);
 	free(target);
+	free(file);
 }


### PR DESCRIPTION
# Fix Segmentation Fault in CLI Test 
This resolves a segmentation fault caused by invalid `write_file` arguments to `parse_cli()` in `cli_test.c`. Previous arguments were `NULL` but this is now resolved by adding a pointer to a char pointer as is intended by the function. Added reassigning of the pointer between function calls, as well as `free()` to avoid memory leaks. 

Closes #21.