### PR TITLE
Fix More Memory Issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ $(OBJS):
 	@$(CC) $(CFLAGS) -o $(BUILD_DIR)/$@ -c $(SRC_DIR)/$*.c
 
 test: dir $(TEST_OBJS) $(OBJS)
+	@ASAN_OPTIONS=leaks=1
 	@$(CC) $(CFLAGSTEST) -o $(TESTS_DIR)/$(BIN_DIR)/run_all_tests \
 	$(patsubst %,$(BUILD_DIR)/%, $(filter-out main.o, $(OBJS))) \
 	$(patsubst %,$(TESTS_DIR)/$(BUILD_DIR)/%, $(TEST_OBJS)) $(LDFLAGS)
@@ -32,6 +33,7 @@ $(TEST_OBJS):
 
 leaks: CFLAGS := $(CFLAGSTEST)
 leaks: clean dir $(NAME)
+	@ASAN_OPTIONS=leaks=1
 	@sudo chmod +x $(TESTS_DIR)/leaks.sh
 	@sudo $(TESTS_DIR)/leaks.sh
 	@$(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,15 @@ CFLAGS := -Wall -Wextra -pedantic -Werror
 CFLAGSTEST := -Wall -Wextra -pedantic -Werror -fsanitize=address -g
 LDFLAGS := -lpcap -lpthread
 
+UNAME := $(shell uname -o)
+
 $(NAME): dir $(OBJS)
 	$(CC) $(CFLAGS) -o $(BIN_DIR)/$@ $(patsubst %,$(BUILD_DIR)/%, $(OBJS)) $(LDFLAGS)
 
 $(OBJS):
 	@$(CC) $(CFLAGS) -o $(BUILD_DIR)/$@ -c $(SRC_DIR)/$*.c
 
-test: dir $(TEST_OBJS) $(OBJS)
+test: dir check_os $(TEST_OBJS) $(OBJS)
 	@ASAN_OPTIONS=leaks=1
 	@$(CC) $(CFLAGSTEST) -o $(TESTS_DIR)/$(BIN_DIR)/run_all_tests \
 	$(patsubst %,$(BUILD_DIR)/%, $(filter-out main.o, $(OBJS))) \
@@ -32,11 +34,16 @@ $(TEST_OBJS):
 	@$(CC) $(CFLAGSTEST) -o $(TESTS_DIR)/$(BUILD_DIR)/$@ -c $(TESTS_DIR)/$*.c
 
 leaks: CFLAGS := $(CFLAGSTEST)
-leaks: clean dir $(NAME)
+leaks: clean dir check_os $(NAME)
 	@ASAN_OPTIONS=leaks=1
 	@sudo chmod +x $(TESTS_DIR)/leaks.sh
 	@sudo $(TESTS_DIR)/leaks.sh
 	@$(MAKE) clean
+
+check_os:
+ifeq ($(UNAME), Darwin)
+	@echo "*** LeakSanitizer is not fully supported on macOS. Leak checks may not work ***"
+endif
 
 dir:
 	@mkdir -p $(BIN_DIR) $(BUILD_DIR) $(TESTS_DIR)/$(BIN_DIR) \
@@ -46,4 +53,4 @@ clean:
 	@rm -rf $(BUILD_DIR) $(BIN_DIR) $(TESTS_DIR)/$(BIN_DIR) \
 	$(TESTS_DIR)/$(BUILD_DIR)
 
-.PHONY: dir test clean leaks
+.PHONY: dir test clean leaks check_os

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Disco is a cross-platform network utility available on Linux and macOS. It suppo
    - [Examples](#examples)
 - [Testing](#testing)
    - [Integration Tests](#integration-tests)
-   - [Memory Leak Tests](#memory-leak-tests)
+   - [Memory Safety Tests](#memory-safety-tests)
 - [Technical Details](#technical-details)
    - [Address Resolution Protocol (ARP)](#address-resolution-protocol-arp)
    - [ICMP Echo Request (Ping)](#icmp-echo-request-ping)
@@ -49,13 +49,13 @@ Disco uses [libpcap](https://www.tcpdump.org/) to enable macOS users to send raw
 
 ### Debian-based Systems
 Update repositories and install `libpcap`
-```bash
+```
 sudo apt update && sudo apt install -y libpcap-dev
 ```
 
 ### macOS
 `libpcap` should come pre-installed on macOS. If it is not, it is available in Homebrew with
-```bash
+```
 brew install libpcap
 ```
 
@@ -73,7 +73,7 @@ disco - network utility for host discovery and port enumeration
 author: pilsnerfrajz
 
 usage: disco target [-h] [-p ports] [-o] [-n] [-P] [-a] [-S]
-					[-w file] [-f]
+                    [-w file] [-f]
 options:
   target          : host to scan (IP address or domain)
   -p, --ports     : ports to scan, e.g., -p 1-1024 or -p 21,22,80
@@ -119,12 +119,15 @@ The program includes comprehensive **integration tests** that validate real netw
 	- Port scan of IPv4/IPv6 external hosts
 - OS Fingerprinting
 	- Windows, Linux and BSD-like (e.g. macOS) systems
-- Memory leaks (see Section [Memory Leak Tests](#memory-leak-tests))
+- Memory safety (see Section [Memory Safety Tests](#memory-safety-tests))
 
 Some tests may fail due to hardcoded IP addresses and port numbers not accessible or open on the targets in your network. Test cases that involve localhost or domains should still pass however. 
 
-### Memory Leak Tests
-Memory leak tests are included to ensure proper memory management. These tests utilize the `AddressSanitizer` available in `clang`. Run with `make leaks` from the project root to execute leak tests with various argument combinations. Each test will report if any memory leaks were detected.
+### Memory Safety Tests
+Memory tests are included to ensure proper memory management. These tests utilize the `AddressSanitizer` and `LeakSanitizer` available in `clang` and `gcc`. Run with `make leaks` from the project root to execute memory tests with various argument combinations. Each test will report if any memory issues were detected.
+
+> [!WARNING]  
+> On macOS, the `LeakSanitizer` is not fully supported and may report false positives. It is recommended to run the tests on Linux for accurate leak detection.
 
 ## Technical Details
 Disco is implemented in C using `libpcap` for frame injection and packet filtering. This section describes the implementation of ARP, ping and port scanning in more detail for those interested.

--- a/src/arp.c
+++ b/src/arp.c
@@ -273,11 +273,11 @@ int compare_subnets(in_addr_t src, in_addr_t dst, in_addr_t mask)
  * @brief Backup function when `getifaddrs` fails to fetch the netmask.
  *
  * @param iface The name of the interface to target.
- * @param mask Pointer to a `sockaddr_in *` to store the netmask in.
+ * @param mask Address of a `sockaddr_in` to store the netmask in.
  * @return int Returns 1 if the netmask is retrieved successfully. Returns
  * 0 if an error occurs.
  */
-int get_mask_ioctl(const char *iface, struct sockaddr_in **mask)
+int get_mask_ioctl(const char *iface, struct sockaddr_in *mask)
 {
 	int fd;
 	struct ifreq ifr;
@@ -293,7 +293,7 @@ int get_mask_ioctl(const char *iface, struct sockaddr_in **mask)
 
 	if (ioctl(fd, SIOCGIFNETMASK, &ifr) == 0)
 	{
-		*mask = (struct sockaddr_in *)&ifr.ifr_addr;
+		memcpy(mask, &ifr.ifr_addr, sizeof(struct sockaddr_in));
 		close(fd);
 		return 1;
 	}
@@ -423,10 +423,10 @@ int get_arp_details(struct sockaddr_in *dst, u_int8_t *src_ip_buf,
 		else if (!interfaces[iface_id].has_mask)
 		{
 			/* Try ioctl as backup */
-			struct sockaddr_in *mask_ptr;
-			if (get_mask_ioctl(interfaces[iface_id].name, &mask_ptr))
+			struct sockaddr_in mask;
+			if (get_mask_ioctl(interfaces[iface_id].name, &mask))
 			{
-				interfaces[iface_id].mask = *mask_ptr;
+				interfaces[iface_id].mask = mask;
 				interfaces[iface_id].has_mask = 1;
 			}
 		}

--- a/tests/arp_test.c
+++ b/tests/arp_test.c
@@ -32,6 +32,10 @@ int arp_possible_test(char *address)
 		free(if_name);
 		return ret;
 	}
+
+	free(if_name);
+	free_dst_addr_struct(dst_info);
+
 	return ret;
 }
 

--- a/tests/leaks.sh
+++ b/tests/leaks.sh
@@ -8,11 +8,11 @@ run_test() {
 	# run binary with argument
 	$BIN "$@" > /dev/null 2> "$ERR_LOG"
 	if grep -q "Sanitizer" "$ERR_LOG"; then
-		echo "❌ Leak test with arguments '$@': failed"
+		echo "❌ Memory test with arguments '$@': failed"
 		cat "$ERR_LOG"
 		exit 1
 	else
-		echo "✅ Leak test with arguments '$@': passed"
+		echo "✅ Memory test with arguments '$@': passed"
 	fi
 	rm -f "$ERR_LOG"
 }


### PR DESCRIPTION
# More Memory Issues
Improves #34 with more memory fixes. Apple `clang` does not fully support `LeakSanitizer` and updating the compilation, and running the tests on Linux revealed uncaught memory leaks. These are now fully fixed, even in the test code. 

## Fixes
- `Makefile`
    - Add warning when testing on macOS
    - Set `ASAN_OPTIONS` to run leak testing
- `tests/arp_test.c`
    - Free unfreed memory in ARP test code
- `src/arp.c`
    - Remove double-pointer to avoid allocating memory on the heap
    - Copy data to the `mask` variable address instead of pointing to function stack-allocated memory

## README
Update README sections to better reflect tests and content. 